### PR TITLE
Proper caching support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tower-http = { version = "0.4.4", default-features = false, features = ["fs"] }
 async_zip = { version = "0.0.15", default-features = false, features = ["tokio"] }
 assert_matches = "1.5.0"
 rstest = { version = "0.18.2" }
+url = { version = "2.4.1" }
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async_http_range_reader"
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A library for streaming reading of files over HTTP using range requests"
 license = "MIT"


### PR DESCRIPTION
Split the `AsyncHttpRangeReader` constructor into the initial request and the subsequent processing and requests to allow moving the initial request into a cache framework. The usage for this is explained in https://github.com/06chaynes/http-cache/issues/57#issuecomment-1802638989, with `wheel_metadata_from_remote_zip` being effectively https://github.com/prefix-dev/rip/pull/66/files#diff-831fc4351ab4266447169dae09f756a01f8c308e024e6836ec91a585695eb992R112-R204 .

The change requires the user to ensure they pass the correct response into `new_tail_response`/`new_head_response`.

Open questions: Which methods should be public, and which ones shouldn't be? Currently i just mad everything public.