### PR TITLE
Update itertools to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["test-data/*"]
 [dependencies]
 futures = "0.3.28"
 http-content-range = "0.1.2"
-itertools = "0.11.0"
+itertools = "0.12.1"
 bisection = "0.1.0"
 memmap2 = "0.9.0"
 reqwest = { version = "0.11.22", default-features = false, features = ["stream"] }


### PR DESCRIPTION
async_http_range_reader is currently the only crate in our dep tree depending on itertools 0.11.