### PR TITLE
refactor: Replace the bisection dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ exclude = ["test-data/*"]
 futures = "0.3.28"
 http-content-range = "0.1.2"
 itertools = "0.12.1"
-bisection = "0.1.0"
 memmap2 = "0.9.0"
 reqwest = { version = "0.12.3", default-features = false, features = ["stream"] }
 reqwest-middleware = "0.3.0"

--- a/src/sparse_range.rs
+++ b/src/sparse_range.rs
@@ -1,4 +1,3 @@
-use bisection::{bisect_left, bisect_right};
 use itertools::Itertools;
 use std::{
     fmt::{Debug, Display, Formatter},
@@ -55,8 +54,8 @@ impl SparseRange {
         let range_end = range.end - 1;
 
         // Compute the indices of the ranges that are covered by the request
-        let left_index = bisect_left(&self.right, &range_start);
-        let right_index = bisect_right(&self.left, &(range_end + 1));
+        let left_index = self.right.partition_point(|x| x < &range_start);
+        let right_index = self.left.partition_point(|x| x <= &(range_end + 1));
 
         // Get all the range bounds that are covered
         let left_slice = &self.left[left_index..right_index];
@@ -97,8 +96,8 @@ impl SparseRange {
         let range_end = range.end - 1;
 
         // Compute the indices of the ranges that are covered by the request
-        let left_index = bisect_left(&self.right, &range_start);
-        let right_index = bisect_right(&self.left, &(range_end + 1));
+        let left_index = self.right.partition_point(|x| x < &range_start);
+        let right_index = self.left.partition_point(|x| x <= &(range_end + 1));
 
         // Get all the range bounds that are covered
         let left_slice = &self.left[left_index..right_index];


### PR DESCRIPTION
The [`bisection` crate](https://crates.io/crates/bisection) appears unmaintained ([last commit four years ago](https://github.com/SteadBytes/bisection)), and has a couple of [unaddressed issues](https://github.com/SteadBytes/bisection/issues). Since Rust 1.52, we can rely on the standard library and use [`partition_point`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.partition_point) instead.

Comparing the definition of [`partition_point`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.partition_point) with the definitions of [`bisect_left`](https://docs.rs/bisection/latest/bisection/fn.bisect_left.html) and [`bisect_right`](https://docs.rs/bisection/latest/bisection/fn.bisect_right.html), I believe this replacement should be exactly equivalent. However, I don’t believe the test coverage is sufficient to catch any subtle errors here, so I recommend closely double-checking my work.